### PR TITLE
fix: bump aiken deps version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,10 +67,10 @@ rand = "0.8.5"
 sha2 = "0.10.6"
 
 [patch.crates-io]
-uplc = { version = "1.0.3-alpha", git = "https://github.com/aiken-lang/aiken.git", branch = "main"}
-aiken = { version = "1.0.3-alpha", git = "https://github.com/aiken-lang/aiken.git", branch = "main"}
-aiken-lang = { version = "1.0.3-alpha", git = "https://github.com/aiken-lang/aiken.git", branch = "main"}
-aiken-project = { version = "1.0.3-alpha", git = "https://github.com/aiken-lang/aiken.git", branch = "main"}
+uplc = { version = "1.0.4-alpha", git = "https://github.com/aiken-lang/aiken.git", branch = "main"}
+aiken = { version = "1.0.4-alpha", git = "https://github.com/aiken-lang/aiken.git", branch = "main"}
+aiken-lang = { version = "1.0.4-alpha", git = "https://github.com/aiken-lang/aiken.git", branch = "main"}
+aiken-project = { version = "1.0.4-alpha", git = "https://github.com/aiken-lang/aiken.git", branch = "main"}
 pallas-addresses = { version = "0.19.0-alpha.0", git = "https://github.com/txpipe/pallas.git"}
 pallas-crypto = { version = "0.19.0-alpha.0", git = "https://github.com/txpipe/pallas.git"}
 


### PR DESCRIPTION
This was preventing me from installing trireme like this:

`cargo install --git https://github.com/free-honey/naumachia.git trireme`