### PR TITLE
Add `current_time` endpoint to LC, update Checking Puller tests

### DIFF
--- a/sample-dApps/checking_account/src/lib.rs
+++ b/sample-dApps/checking_account/src/lib.rs
@@ -106,6 +106,8 @@ pub enum CheckingAccountError {
     CannotWithdrawSpecifiedAmount,
     #[error("Address isn't valid: {0:?}")]
     InvalidAddress(Address),
+    #[error("Too early to pull: next_pull: {next_pull}, current_time: {current_time}")]
+    TooEarlyToPull { next_pull: i64, current_time: i64 },
 }
 
 #[async_trait]

--- a/src/ledger_client.rs
+++ b/src/ledger_client.rs
@@ -53,6 +53,8 @@ pub trait LedgerClient<Datum, Redeemer>: Send + Sync {
     async fn issue(&self, tx: UnbuiltTransaction<Datum, Redeemer>) -> LedgerClientResult<TxId>; // TODO: Move to other trait
 
     async fn network(&self) -> LedgerClientResult<Network>;
+
+    async fn current_time_posix_milliseconds(&self) -> LedgerClientResult<i64>;
 }
 
 #[derive(Debug, Error)]

--- a/src/ledger_client/test_ledger_client/local_persisted_storage.rs
+++ b/src/ledger_client/test_ledger_client/local_persisted_storage.rs
@@ -339,6 +339,7 @@ mod tests {
             signer_name,
             &signer,
             starting_amount,
+            0,
             BLOCK_LENGTH,
         );
         let mut outputs = storage.all_outputs(&signer).await.unwrap();
@@ -360,6 +361,7 @@ mod tests {
             signer_name,
             &signer,
             starting_amount,
+            0,
             BLOCK_LENGTH,
         );
         let current_time = storage.current_time().await.unwrap();
@@ -382,6 +384,7 @@ mod tests {
             alice,
             &alice_address,
             starting_amount,
+            0,
             BLOCK_LENGTH,
         );
         let bob = "Bob";

--- a/src/ledger_client/test_ledger_client/local_persisted_storage.rs
+++ b/src/ledger_client/test_ledger_client/local_persisted_storage.rs
@@ -141,12 +141,14 @@ where
         signer_name: &str,
         signer: &Address,
         starting_amount: u64,
+        starting_time: i64,
         block_length: i64,
     ) -> Self {
         let path_ref: &Path = dir.as_ref();
         let path = path_ref.to_owned().join(DATA);
         if !path.exists() {
             let mut data = LedgerData::new(signer_name, signer, block_length);
+            data.current_time = starting_time;
             let output: Output<Datum> = starting_output(signer, starting_amount);
             data.add_output(output); // TODO: Parameterize
             let serialized = serde_json::to_string(&data).unwrap();

--- a/src/ledger_client/test_ledger_client/tests.rs
+++ b/src/ledger_client/test_ledger_client/tests.rs
@@ -24,7 +24,7 @@ async fn outputs_at_address() {
     let output = starting_output::<()>(&signer, starting_amount);
     let outputs = vec![(signer.clone(), output)];
     let record: TestLedgerClient<(), (), _> =
-        TestLedgerClient::new_in_memory(signer.clone(), outputs, BLOCK_LENGTH);
+        TestLedgerClient::new_in_memory(signer.clone(), outputs, BLOCK_LENGTH, 0);
     let mut outputs = record.all_outputs_at_address(&signer).await.unwrap();
     assert_eq!(outputs.len(), 1);
     let first_output = outputs.pop().unwrap();
@@ -40,7 +40,7 @@ async fn balance_at_address() {
     let output = starting_output::<()>(&signer, starting_amount);
     let outputs = vec![(signer.clone(), output)];
     let record: TestLedgerClient<(), (), _> =
-        TestLedgerClient::new_in_memory(signer.clone(), outputs, BLOCK_LENGTH);
+        TestLedgerClient::new_in_memory(signer.clone(), outputs, BLOCK_LENGTH, 0);
     let expected = starting_amount;
     let actual = record
         .balance_at_address(&signer, &PolicyId::Lovelace)
@@ -57,7 +57,7 @@ async fn issue_transfer() {
     let output = starting_output::<()>(&sender, starting_amount);
     let outputs = vec![(sender.clone(), output)];
     let record: TestLedgerClient<(), (), _> =
-        TestLedgerClient::new_in_memory(sender.clone(), outputs, BLOCK_LENGTH);
+        TestLedgerClient::new_in_memory(sender.clone(), outputs, BLOCK_LENGTH, 0);
 
     let mut values = Values::default();
     values.add_one_value(&PolicyId::Lovelace, transfer_amount);
@@ -101,7 +101,7 @@ async fn issuing_tx_advances_time_by_block_length() {
     let signer = Address::from_bech32(ALICE).unwrap();
     let outputs = vec![];
     let record: TestLedgerClient<(), (), _> =
-        TestLedgerClient::new_in_memory(signer.clone(), outputs, BLOCK_LENGTH);
+        TestLedgerClient::new_in_memory(signer.clone(), outputs, BLOCK_LENGTH, 0);
     let starting_time = record.current_time().await.unwrap();
     let tx = UnbuiltTransaction {
         script_version: TransactionVersion::V2,
@@ -123,7 +123,7 @@ async fn errors_if_spending_more_than_you_own() {
     let transfer_amount = 3_000_000;
     let outputs = vec![];
     let record: TestLedgerClient<(), (), _> =
-        TestLedgerClient::new_in_memory(sender.clone(), outputs, BLOCK_LENGTH);
+        TestLedgerClient::new_in_memory(sender.clone(), outputs, BLOCK_LENGTH, 0);
 
     let mut values = Values::default();
     values.add_one_value(&PolicyId::Lovelace, transfer_amount);
@@ -151,7 +151,7 @@ async fn cannot_transfer_before_valid_range() {
     let output = starting_output::<()>(&sender, starting_amount);
     let outputs = vec![(sender.clone(), output)];
     let record: TestLedgerClient<(), (), _> =
-        TestLedgerClient::new_in_memory(sender.clone(), outputs, BLOCK_LENGTH);
+        TestLedgerClient::new_in_memory(sender.clone(), outputs, BLOCK_LENGTH, 0);
 
     let current_time = 5;
     let valid_time = 10;
@@ -183,7 +183,7 @@ async fn cannot_transfer_after_valid_range() {
     let output = starting_output::<()>(&sender, starting_amount);
     let outputs = vec![(sender.clone(), output)];
     let record: TestLedgerClient<(), (), _> =
-        TestLedgerClient::new_in_memory(sender.clone(), outputs, BLOCK_LENGTH);
+        TestLedgerClient::new_in_memory(sender.clone(), outputs, BLOCK_LENGTH, 0);
 
     let current_time = 10;
     let valid_time = 5;
@@ -235,7 +235,7 @@ async fn redeeming_datum() {
     let output = starting_output::<()>(&sender, starting_amount);
     let outputs = vec![(sender.clone(), output)];
     let record: TestLedgerClient<(), (), _> =
-        TestLedgerClient::new_in_memory(sender.clone(), outputs, BLOCK_LENGTH);
+        TestLedgerClient::new_in_memory(sender.clone(), outputs, BLOCK_LENGTH, 0);
 
     let mut values = Values::default();
     values.add_one_value(&PolicyId::Lovelace, locking_amount);
@@ -329,7 +329,7 @@ async fn failing_script_will_not_redeem() {
     let output = starting_output::<()>(&sender, starting_amount);
     let outputs = vec![(sender.clone(), output)];
     let record: TestLedgerClient<(), (), _> =
-        TestLedgerClient::new_in_memory(sender.clone(), outputs, BLOCK_LENGTH);
+        TestLedgerClient::new_in_memory(sender.clone(), outputs, BLOCK_LENGTH, 0);
 
     let mut values = Values::default();
     values.add_one_value(&PolicyId::Lovelace, locking_amount);
@@ -391,7 +391,7 @@ async fn cannot_redeem_datum_twice() {
     let output = starting_output::<()>(&sender, starting_amount);
     let outputs = vec![(sender.clone(), output)];
     let record: TestLedgerClient<(), (), _> =
-        TestLedgerClient::new_in_memory(sender.clone(), outputs, BLOCK_LENGTH);
+        TestLedgerClient::new_in_memory(sender.clone(), outputs, BLOCK_LENGTH, 0);
 
     let mut values = Values::default();
     values.add_one_value(&PolicyId::Lovelace, locking_amount);
@@ -473,7 +473,7 @@ async fn mint_always_true() {
     let output = starting_output::<()>(&sender, starting_amount);
     let outputs = vec![(sender.clone(), output)];
     let record: TestLedgerClient<(), (), _> =
-        TestLedgerClient::new_in_memory(sender.clone(), outputs, BLOCK_LENGTH);
+        TestLedgerClient::new_in_memory(sender.clone(), outputs, BLOCK_LENGTH, 0);
 
     let policy = AlwaysTruePolicy;
     let id = policy.id().unwrap();
@@ -521,7 +521,7 @@ async fn mint_always_fails_errors() {
     let output = starting_output::<()>(&sender, starting_amount);
     let outputs = vec![(sender.clone(), output)];
     let record: TestLedgerClient<(), (), _> =
-        TestLedgerClient::new_in_memory(sender.clone(), outputs, BLOCK_LENGTH);
+        TestLedgerClient::new_in_memory(sender.clone(), outputs, BLOCK_LENGTH, 0);
 
     let policy = AlwaysFailsPolicy;
     let id = policy.id().unwrap();
@@ -588,7 +588,7 @@ async fn spends_specific_script_value() {
     let output = starting_output::<()>(&minter, starting_amount);
     let outputs = vec![(minter.clone(), output), (val_address, input.clone())];
     let record: TestLedgerClient<(), (), _> =
-        TestLedgerClient::new_in_memory(minter.clone(), outputs, BLOCK_LENGTH);
+        TestLedgerClient::new_in_memory(minter.clone(), outputs, BLOCK_LENGTH, 0);
 
     let policy = SpendsNFTPolicy {
         policy_id: nft_policy_id,

--- a/src/output.rs
+++ b/src/output.rs
@@ -68,6 +68,22 @@ pub enum DatumKind<Datum> {
     None,
 }
 
+impl<Datum> DatumKind<Datum> {
+    pub fn unwrap_typed(self) -> Datum {
+        match self {
+            DatumKind::Typed(datum) => datum,
+            _ => panic!("Expected Typed Datum"),
+        }
+    }
+
+    pub fn unwrap_untyped(self) -> PlutusData {
+        match self {
+            DatumKind::UnTyped(datum) => datum,
+            _ => panic!("Expected Untyped Datum"),
+        }
+    }
+}
+
 impl<Datum> From<DatumKind<Datum>> for Option<Datum> {
     fn from(value: DatumKind<Datum>) -> Self {
         match value {

--- a/src/trireme_ledger_client.rs
+++ b/src/trireme_ledger_client.rs
@@ -523,6 +523,15 @@ where
         }
         .await
     }
+
+    async fn current_time_posix_milliseconds(&self) -> LedgerClientResult<i64> {
+        match &self.inner_client {
+            InnerClient::BlockFrost(cml_client) => cml_client.current_time_posix_milliseconds(),
+            InnerClient::Mocked(test_client) => test_client.current_time_posix_milliseconds(),
+            InnerClient::OgmiosScrolls(cml_client) => cml_client.current_time_posix_milliseconds(),
+        }
+        .await
+    }
 }
 
 #[derive(Debug, Error)]

--- a/src/trireme_ledger_client/cml_client.rs
+++ b/src/trireme_ledger_client/cml_client.rs
@@ -36,6 +36,7 @@ use cardano_multiplatform_lib::{
 };
 use error::*;
 use pallas_addresses::{Address, Network};
+use std::time::UNIX_EPOCH;
 use std::{collections::HashMap, fmt::Debug, marker::PhantomData, ops::Deref};
 
 pub mod blockfrost_ledger;
@@ -674,5 +675,15 @@ where
             _ => Network::Other(self.network),
         };
         Ok(network)
+    }
+
+    async fn current_time_posix_milliseconds(&self) -> LedgerClientResult<i64> {
+        let now = std::time::SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map_err(|e| LedgerClientError::CurrentTime(Box::new(e)))?
+            .as_millis()
+            .try_into()
+            .expect("This should never be bigger than i64 in our lifetimes :)");
+        Ok(now)
     }
 }

--- a/trireme/src/environment.rs
+++ b/trireme/src/environment.rs
@@ -222,11 +222,14 @@ async fn setup_local_mocked_env(name: &str) -> Result<()> {
         "Could not find parent directory for config".to_string(),
     ))?;
     fs::create_dir_all(&parent_dir).await?;
+
+    let starting_time = 0;
     let storage = LocalPersistedStorage::<PathBuf, ()>::init(
         parent_dir.into(),
         alice_name,
         &alice_address,
         start_balance,
+        starting_time,
         block_length,
     );
     storage.add_new_signer(bob_name, &bob_address, start_balance);


### PR DESCRIPTION
Adds a `current_time` endpoint to the `LedgerClient` which can be used inside contracts or outside them.

This is context-specific time. Meaning, if it's a test client, the time might not correlate to real time at all. Important for tests.