### PR TITLE
Have SC own logic and backend instead of hold ref

### DIFF
--- a/sample-dApps/always-succeeds-contract/src/logic/tests.rs
+++ b/sample-dApps/always-succeeds-contract/src/logic/tests.rs
@@ -16,13 +16,14 @@ async fn lock_and_claim() {
     let amount = 10_000_000;
     let endpoint = AlwaysSucceedsEndpoints::Lock { amount };
     let script = get_script().unwrap();
-    let contract = SmartContract::new(&AlwaysSucceedsLogic, &backend);
+    let contract = SmartContract::new(AlwaysSucceedsLogic, backend);
     contract.hit_endpoint(endpoint).await.unwrap();
     let network = Network::Testnet;
     {
         let expected = amount;
-        let actual = backend
-            .ledger_client
+        let actual = contract
+            .backend()
+            .ledger_client()
             .balance_at_address(&script.address(network).unwrap(), &PolicyId::Lovelace)
             .await
             .unwrap();
@@ -31,15 +32,17 @@ async fn lock_and_claim() {
 
     {
         let expected = start_amount - amount;
-        let actual = backend
-            .ledger_client
+        let actual = contract
+            .backend()
+            .ledger_client()
             .balance_at_address(&me, &PolicyId::Lovelace)
             .await
             .unwrap();
         assert_eq!(expected, actual);
     }
-    let instance = backend
-        .ledger_client
+    let instance = contract
+        .backend()
+        .ledger_client()
         .all_outputs_at_address(&script.address(network).unwrap())
         .await
         .unwrap()
@@ -51,16 +54,18 @@ async fn lock_and_claim() {
 
     contract.hit_endpoint(call).await.unwrap();
     {
-        let actual = backend
-            .ledger_client
+        let actual = contract
+            .backend()
+            .ledger_client()
             .balance_at_address(&me, &PolicyId::Lovelace)
             .await
             .unwrap();
         assert_eq!(actual, start_amount);
     }
     {
-        let script_balance = backend
-            .ledger_client
+        let script_balance = contract
+            .backend()
+            .ledger_client()
             .balance_at_address(&script.address(network).unwrap(), &PolicyId::Lovelace)
             .await
             .unwrap();

--- a/sample-dApps/always-succeeds-contract/src/main.rs
+++ b/sample-dApps/always-succeeds-contract/src/main.rs
@@ -34,7 +34,7 @@ async fn main() {
     let logic = AlwaysSucceedsLogic;
     let ledger_client = get_trireme_ledger_client_from_file().await.unwrap();
     let backend = Backend::new(ledger_client);
-    let contract = SmartContract::new(&logic, &backend);
+    let contract = SmartContract::new(logic, backend);
 
     match args.action {
         ActionParams::Lock { amount } => contract

--- a/sample-dApps/checking_account/src/datum.rs
+++ b/sample-dApps/checking_account/src/datum.rs
@@ -88,7 +88,7 @@ impl TryFrom<PlutusData> for CheckingAccountDatums {
 
     fn try_from(value: PlutusData) -> Result<Self, Self::Error> {
         let PlutusData::Constr(constr) = value else {
-            return Err(())
+            return Err(());
         };
 
         let datum = match constr.fields.len() {
@@ -102,9 +102,13 @@ impl TryFrom<PlutusData> for CheckingAccountDatums {
 }
 
 fn checking_account_datum(fields: &[PlutusData]) -> Result<CheckingAccountDatums, ()> {
-    let PlutusData::BoundedBytes(owner_bytes) = fields.get(0).ok_or(())? else { return Err(())};
+    let PlutusData::BoundedBytes(owner_bytes) = fields.get(0).ok_or(())? else {
+        return Err(());
+    };
     let owner = PubKeyHash::new(&owner_bytes);
-    let PlutusData::BoundedBytes(policy_bytes) = fields.get(1).ok_or(())? else { return Err(())};
+    let PlutusData::BoundedBytes(policy_bytes) = fields.get(1).ok_or(())? else {
+        return Err(());
+    };
     let spend_token_policy = policy_bytes.to_vec();
     Ok(CheckingAccount {
         owner,
@@ -114,19 +118,32 @@ fn checking_account_datum(fields: &[PlutusData]) -> Result<CheckingAccountDatums
 }
 
 fn allowed_puller(fields: &[PlutusData]) -> Result<CheckingAccountDatums, ()> {
-    let PlutusData::BoundedBytes(owner_bytes) = fields.get(0).ok_or(())? else { return Err(())};
+    let PlutusData::BoundedBytes(owner_bytes) = fields.get(0).ok_or(())? else {
+        return Err(())};
     let owner = PubKeyHash::new(&owner_bytes);
-    let PlutusData::BoundedBytes(puller_bytes) = fields.get(1).ok_or(())? else { return Err(())};
+    let PlutusData::BoundedBytes(puller_bytes) = fields.get(1).ok_or(())? else {
+        return Err(());
+    };
     let puller = PubKeyHash::new(&puller_bytes);
-    let PlutusData::BigInt(amount_lovelace) = fields.get(2).ok_or(())? else { return Err(())};
+    let PlutusData::BigInt(amount_lovelace) = fields.get(2).ok_or(())? else {
+        return Err(());
+    };
     let amount_lovelace: i64 = amount_lovelace.into();
-    let PlutusData::BigInt(next_pull) = fields.get(3).ok_or(())? else { return Err(())};
+    let PlutusData::BigInt(next_pull) = fields.get(3).ok_or(())? else {
+        return Err(());
+    };
     let next_pull: i64 = next_pull.into();
-    let PlutusData::BigInt(period) = fields.get(4).ok_or(())? else { return Err(())};
+    let PlutusData::BigInt(period) = fields.get(4).ok_or(())? else {
+        return Err(());
+    };
     let period: i64 = period.into();
-    let PlutusData::BoundedBytes(spending_token) = fields.get(5).ok_or(())? else { return Err(())};
+    let PlutusData::BoundedBytes(spending_token) = fields.get(5).ok_or(())? else {
+        return Err(());
+    };
     let spending_token = spending_token.to_vec();
-    let PlutusData::BoundedBytes(checking_account_nft) = fields.get(6).ok_or(())? else { return Err(())};
+    let PlutusData::BoundedBytes(checking_account_nft) = fields.get(6).ok_or(())? else {
+        return Err(());
+    };
     let checking_account_nft = checking_account_nft.to_vec();
     let datum = CheckingAccountDatums::AllowedPuller(AllowedPuller {
         owner,

--- a/sample-dApps/checking_account/src/datum.rs
+++ b/sample-dApps/checking_account/src/datum.rs
@@ -119,7 +119,8 @@ fn checking_account_datum(fields: &[PlutusData]) -> Result<CheckingAccountDatums
 
 fn allowed_puller(fields: &[PlutusData]) -> Result<CheckingAccountDatums, ()> {
     let PlutusData::BoundedBytes(owner_bytes) = fields.get(0).ok_or(())? else {
-        return Err(())};
+        return Err(())
+    };
     let owner = PubKeyHash::new(&owner_bytes);
     let PlutusData::BoundedBytes(puller_bytes) = fields.get(1).ok_or(())? else {
         return Err(());

--- a/sample-dApps/checking_account/src/datum.rs
+++ b/sample-dApps/checking_account/src/datum.rs
@@ -119,7 +119,7 @@ fn checking_account_datum(fields: &[PlutusData]) -> Result<CheckingAccountDatums
 
 fn allowed_puller(fields: &[PlutusData]) -> Result<CheckingAccountDatums, ()> {
     let PlutusData::BoundedBytes(owner_bytes) = fields.get(0).ok_or(())? else {
-        return Err(())
+        return Err(());
     };
     let owner = PubKeyHash::new(&owner_bytes);
     let PlutusData::BoundedBytes(puller_bytes) = fields.get(1).ok_or(())? else {

--- a/sample-dApps/checking_account/src/endpoints/tests.rs
+++ b/sample-dApps/checking_account/src/endpoints/tests.rs
@@ -33,15 +33,16 @@ async fn init_creates_instance_with_correct_balance() {
     let endpoint = CheckingAccountEndpoints::InitAccount {
         starting_lovelace: account_amount,
     };
-    let contract = SmartContract::new(&CheckingAccountLogic, &backend);
+    let contract = SmartContract::new(CheckingAccountLogic, backend);
     contract.hit_endpoint(endpoint).await.unwrap();
 
     // Then
     let script = checking_account_validator().unwrap();
     let network = Network::Testnet;
     let address = script.address(network).unwrap();
-    let mut outputs_at_address = backend
-        .ledger_client
+    let mut outputs_at_address = contract
+        .backend()
+        .ledger_client()
         .all_outputs_at_address(&address)
         .await
         .unwrap();
@@ -74,13 +75,14 @@ async fn add_puller_creates_new_datum_for_puller() {
         period: 1000,
         next_pull: 0,
     };
-    let contract = SmartContract::new(&CheckingAccountLogic, &backend);
+    let contract = SmartContract::new(CheckingAccountLogic, backend);
     contract.hit_endpoint(endpoint).await.unwrap();
     let script = pull_validator().unwrap();
     let network = Network::Testnet;
     let script_address = script.address(network).unwrap();
-    let mut outputs_at_address = backend
-        .ledger_client
+    let mut outputs_at_address = contract
+        .backend()
+        .ledger_client()
         .all_outputs_at_address(&script_address)
         .await
         .unwrap();
@@ -125,13 +127,14 @@ async fn remove_puller__removes_the_allowed_puller() {
         next_pull: 0,
     };
 
-    let contract = SmartContract::new(&CheckingAccountLogic, &backend);
+    let contract = SmartContract::new(CheckingAccountLogic, backend);
     contract.hit_endpoint(add_endpoint).await.unwrap();
     let script = pull_validator().unwrap();
     let network = Network::Testnet;
     let address = script.address(network).unwrap();
-    let mut outputs_at_address = backend
-        .ledger_client
+    let mut outputs_at_address = contract
+        .backend()
+        .ledger_client()
         .all_outputs_at_address(&address)
         .await
         .unwrap();
@@ -142,8 +145,9 @@ async fn remove_puller__removes_the_allowed_puller() {
 
     contract.hit_endpoint(remove_endpoint).await.unwrap();
 
-    let mut outputs_at_address = backend
-        .ledger_client
+    let mut outputs_at_address = contract
+        .backend()
+        .ledger_client()
         .all_outputs_at_address(&address)
         .await
         .unwrap();
@@ -166,14 +170,15 @@ async fn fund_account__replaces_existing_balance_with_updated_amount() {
         starting_lovelace: account_amount,
     };
 
-    let contract = SmartContract::new(&CheckingAccountLogic, &backend);
+    let contract = SmartContract::new(CheckingAccountLogic, backend);
     contract.hit_endpoint(init_endpoint).await.unwrap();
 
     let script = checking_account_validator().unwrap();
     let network = Network::Testnet;
     let address = script.address(network).unwrap();
-    let mut outputs_at_address = backend
-        .ledger_client
+    let mut outputs_at_address = contract
+        .backend()
+        .ledger_client()
         .all_outputs_at_address(&address)
         .await
         .unwrap();
@@ -186,8 +191,9 @@ async fn fund_account__replaces_existing_balance_with_updated_amount() {
     };
 
     contract.hit_endpoint(fund_endpoint).await.unwrap();
-    let mut outputs_at_address = backend
-        .ledger_client
+    let mut outputs_at_address = contract
+        .backend()
+        .ledger_client()
         .all_outputs_at_address(&address)
         .await
         .unwrap();
@@ -211,14 +217,15 @@ async fn withdraw_from_account__replaces_existing_balance_with_updated_amount() 
     let init_endpoint = CheckingAccountEndpoints::InitAccount {
         starting_lovelace: account_amount,
     };
-    let contract = SmartContract::new(&CheckingAccountLogic, &backend);
+    let contract = SmartContract::new(CheckingAccountLogic, backend);
     contract.hit_endpoint(init_endpoint).await.unwrap();
 
     let script = checking_account_validator().unwrap();
     let network = Network::Testnet;
     let address = script.address(network).unwrap();
-    let mut outputs_at_address = backend
-        .ledger_client
+    let mut outputs_at_address = contract
+        .backend()
+        .ledger_client()
         .all_outputs_at_address(&address)
         .await
         .unwrap();
@@ -231,8 +238,9 @@ async fn withdraw_from_account__replaces_existing_balance_with_updated_amount() 
     };
 
     contract.hit_endpoint(fund_endpoint).await.unwrap();
-    let mut outputs_at_address = backend
-        .ledger_client
+    let mut outputs_at_address = contract
+        .backend()
+        .ledger_client()
         .all_outputs_at_address(&address)
         .await
         .unwrap();
@@ -294,18 +302,20 @@ async fn pull_from_account__replaces_existing_balances_with_updated_amounts_and_
         .finish_output()
         .build_in_memory();
 
-    let contract = SmartContract::new(&CheckingAccountLogic, &backend);
+    let contract = SmartContract::new(CheckingAccountLogic, backend);
 
-    let mut outputs_at_address = backend
-        .ledger_client
+    let mut outputs_at_address = contract
+        .backend()
+        .ledger_client()
         .all_outputs_at_address(&account_address)
         .await
         .unwrap();
     let script_output = outputs_at_address.pop().unwrap();
     let checking_account_output_id = script_output.id().to_owned();
 
-    let mut outputs_at_address = backend
-        .ledger_client
+    let mut outputs_at_address = contract
+        .backend()
+        .ledger_client()
         .all_outputs_at_address(&allow_puller_address)
         .await
         .unwrap();
@@ -321,8 +331,9 @@ async fn pull_from_account__replaces_existing_balances_with_updated_amounts_and_
     contract.hit_endpoint(pull_endpoint).await.unwrap();
 
     // Then
-    let mut outputs_at_account_address = backend
-        .ledger_client
+    let mut outputs_at_account_address = contract
+        .backend()
+        .ledger_client()
         .all_outputs_at_address(&account_address)
         .await
         .unwrap();
@@ -330,8 +341,9 @@ async fn pull_from_account__replaces_existing_balances_with_updated_amounts_and_
     let value = script_output.values().get(&PolicyId::Lovelace).unwrap();
     assert_eq!(value, account_amount - pull_amount);
 
-    let mut outputs_at_puller_address = backend
-        .ledger_client
+    let mut outputs_at_puller_address = contract
+        .backend()
+        .ledger_client()
         .all_outputs_at_address(&puller)
         .await
         .unwrap();
@@ -339,8 +351,9 @@ async fn pull_from_account__replaces_existing_balances_with_updated_amounts_and_
     let value = script_output.values().get(&PolicyId::Lovelace).unwrap();
     assert_eq!(value, pull_amount);
 
-    let mut outputs_at_account_address = backend
-        .ledger_client
+    let mut outputs_at_account_address = contract
+        .backend()
+        .ledger_client()
         .all_outputs_at_address(&allow_puller_address)
         .await
         .unwrap();
@@ -408,18 +421,20 @@ async fn pull_from_account__fails_if_time_not_past_next_pull_time() {
         .finish_output()
         .build_in_memory();
 
-    let contract = SmartContract::new(&CheckingAccountLogic, &backend);
+    let contract = SmartContract::new(CheckingAccountLogic, backend);
 
-    let mut outputs_at_address = backend
-        .ledger_client
+    let mut outputs_at_address = contract
+        .backend()
+        .ledger_client()
         .all_outputs_at_address(&account_address)
         .await
         .unwrap();
     let script_output = outputs_at_address.pop().unwrap();
     let checking_account_output_id = script_output.id().to_owned();
 
-    let mut outputs_at_address = backend
-        .ledger_client
+    let mut outputs_at_address = contract
+        .backend()
+        .ledger_client()
         .all_outputs_at_address(&allow_puller_address)
         .await
         .unwrap();

--- a/sample-dApps/checking_account/src/main.rs
+++ b/sample-dApps/checking_account/src/main.rs
@@ -46,7 +46,7 @@ async fn hit_endpoint(endpoint: CheckingAccountEndpoints) -> Result<()> {
     let logic = CheckingAccountLogic;
     let ledger_client = get_trireme_ledger_client_from_file().await?;
     let backend = Backend::new(ledger_client);
-    let contract = SmartContract::new(&logic, &backend);
+    let contract = SmartContract::new(logic, backend);
     let res = contract.hit_endpoint(endpoint).await?;
     Ok(res)
 }
@@ -55,7 +55,7 @@ async fn run_lookup(lookup: CheckingAccountLookups) -> Result<CheckingAccountLoo
     let logic = CheckingAccountLogic;
     let ledger_client = get_trireme_ledger_client_from_file().await?;
     let backend = Backend::new(ledger_client);
-    let contract = SmartContract::new(&logic, &backend);
+    let contract = SmartContract::new(logic, backend);
     let res = contract.lookup(lookup).await?;
     Ok(res)
 }

--- a/sample-dApps/free-minting-contract/src/main.rs
+++ b/sample-dApps/free-minting-contract/src/main.rs
@@ -26,7 +26,7 @@ async fn main() {
     let logic = FreeMintingLogic;
     let ledger_client = get_trireme_ledger_client_from_file().await.unwrap();
     let backend = Backend::new(ledger_client);
-    let contract = SmartContract::new(&logic, &backend);
+    let contract = SmartContract::new(logic, backend);
 
     match args.action {
         ActionParams::Mint { amount } => contract

--- a/sample-dApps/game-contract/src/logic/tests.rs
+++ b/sample-dApps/game-contract/src/logic/tests.rs
@@ -24,13 +24,14 @@ async fn lock_and_claim() {
         secret: secret.to_string(),
     };
     let script = get_script().unwrap();
-    let contract = SmartContract::new(&GameLogic, &backend);
+    let contract = SmartContract::new(GameLogic, backend);
     let network = Network::Testnet;
     contract.hit_endpoint(endpoint).await.unwrap();
     {
         let expected = amount;
-        let actual = backend
-            .ledger_client
+        let actual = contract
+            .backend()
+            .ledger_client()
             .balance_at_address(&script.address(network).unwrap(), &PolicyId::Lovelace)
             .await
             .unwrap();
@@ -39,15 +40,17 @@ async fn lock_and_claim() {
 
     {
         let expected = start_amount - amount;
-        let actual = backend
-            .ledger_client
+        let actual = contract
+            .backend()
+            .ledger_client()
             .balance_at_address(&me, &PolicyId::Lovelace)
             .await
             .unwrap();
         assert_eq!(expected, actual);
     }
-    let instance = backend
-        .ledger_client
+    let instance = contract
+        .backend()
+        .ledger_client()
         .all_outputs_at_address(&script.address(network).unwrap())
         .await
         .unwrap()
@@ -60,16 +63,18 @@ async fn lock_and_claim() {
 
     contract.hit_endpoint(call).await.unwrap();
     {
-        let actual = backend
-            .ledger_client
+        let actual = contract
+            .backend()
+            .ledger_client()
             .balance_at_address(&me, &PolicyId::Lovelace)
             .await
             .unwrap();
         assert_eq!(actual, start_amount);
     }
     {
-        let script_balance = backend
-            .ledger_client
+        let script_balance = contract
+            .backend()
+            .ledger_client()
             .balance_at_address(&script.address(network).unwrap(), &PolicyId::Lovelace)
             .await
             .unwrap();

--- a/sample-dApps/game-contract/src/main.rs
+++ b/sample-dApps/game-contract/src/main.rs
@@ -35,7 +35,7 @@ async fn main() {
     let logic = GameLogic;
     let ledger_client = get_trireme_ledger_client_from_file().await.unwrap();
     let backend = Backend::new(ledger_client);
-    let contract = SmartContract::new(&logic, &backend);
+    let contract = SmartContract::new(logic, backend);
 
     match args.action {
         ActionParams::Lock { amount, secret } => {

--- a/sample-dApps/mint_nft/src/main.rs
+++ b/sample-dApps/mint_nft/src/main.rs
@@ -26,7 +26,7 @@ async fn main() {
     let logic = MintNFTLogic;
     let ledger_client = get_trireme_ledger_client_from_file().await.unwrap();
     let backend = Backend::new(ledger_client);
-    let contract = SmartContract::new(&logic, &backend);
+    let contract = SmartContract::new(logic, backend);
 
     match args.action {
         ActionParams::Mint => contract.hit_endpoint(MintNFTEndpoints::Mint).await.unwrap(),

--- a/sample-dApps/time-locked-contract/src/logic.rs
+++ b/sample-dApps/time-locked-contract/src/logic.rs
@@ -160,15 +160,16 @@ mod tests {
 
         let endpoint = TimeLockedEndpoints::Lock { amount, after_secs };
 
-        let contract = SmartContract::new(&TimeLockedLogic, &backend);
+        let contract = SmartContract::new(TimeLockedLogic, backend);
 
         // when
         contract.hit_endpoint(endpoint).await.unwrap();
 
         // then
-        let network = backend.ledger_client().network().await.unwrap();
+        let network = contract.backend().ledger_client().network().await.unwrap();
         let script_address = get_script().unwrap().address(network).unwrap();
-        let outputs = backend
+        let outputs = contract
+            .backend()
             .ledger_client()
             .all_outputs_at_address(&script_address)
             .await
@@ -216,20 +217,22 @@ mod tests {
                 .clone(),
         };
 
-        let contract = SmartContract::new(&TimeLockedLogic, &backend);
+        let contract = SmartContract::new(TimeLockedLogic, backend);
 
         // when
         contract.hit_endpoint(endpoint).await.unwrap();
 
         // then
-        let outputs = backend
+        let outputs = contract
+            .backend()
             .ledger_client()
             .all_outputs_at_address(&script_address)
             .await
             .unwrap();
         assert!(outputs.is_empty());
 
-        let my_balance = backend
+        let my_balance = contract
+            .backend()
             .ledger_client()
             .balance_at_address(&me, &PolicyId::Lovelace)
             .await
@@ -271,7 +274,7 @@ mod tests {
                 .clone(),
         };
 
-        let contract = SmartContract::new(&TimeLockedLogic, &backend);
+        let contract = SmartContract::new(TimeLockedLogic, backend);
 
         // when
         let res = contract.hit_endpoint(endpoint).await;

--- a/sample-dApps/time-locked-contract/src/main.rs
+++ b/sample-dApps/time-locked-contract/src/main.rs
@@ -33,7 +33,7 @@ async fn main() {
     let logic = TimeLockedLogic;
     let ledger_client = get_trireme_ledger_client_from_file().await.unwrap();
     let backend = Backend::new(ledger_client);
-    let contract = SmartContract::new(&logic, &backend);
+    let contract = SmartContract::new(logic, backend);
 
     match args.action {
         ActionParams::Lock { amount, after_secs } => contract

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -14,10 +14,9 @@ where
     Redeemer: Clone + Eq,
     LC: LedgerClient<Datum, Redeemer>,
 {
-    // TODO: Make fields private
-    pub _datum: PhantomData<Datum>,
-    pub _redeemer: PhantomData<Redeemer>,
-    pub ledger_client: LC,
+    pub(crate) _datum: PhantomData<Datum>,
+    pub(crate) _redeemer: PhantomData<Redeemer>,
+    pub(crate) ledger_client: LC,
 }
 
 pub type RedemptionDetails<Datum, Redeemer> = (

--- a/src/smart_contract.rs
+++ b/src/smart_contract.rs
@@ -13,33 +13,41 @@ pub trait SmartContractTrait {
 }
 
 #[derive(Debug)]
-pub struct SmartContract<'a, Logic, Record>
+pub struct SmartContract<Logic, Record>
 where
     Logic: SCLogic,
     Record: LedgerClient<Logic::Datums, Logic::Redeemers>,
 {
-    pub offchain_logic: &'a Logic,
-    pub backend: &'a Backend<Logic::Datums, Logic::Redeemers, Record>,
+    offchain_logic: Logic,
+    backend: Backend<Logic::Datums, Logic::Redeemers, Record>,
 }
 
-impl<'a, Logic, Record> SmartContract<'a, Logic, Record>
+impl<Logic, Record> SmartContract<Logic, Record>
 where
     Logic: SCLogic,
     Record: LedgerClient<Logic::Datums, Logic::Redeemers>,
 {
     pub fn new(
-        offchain_logic: &'a Logic,
-        backend: &'a Backend<Logic::Datums, Logic::Redeemers, Record>,
+        offchain_logic: Logic,
+        backend: Backend<Logic::Datums, Logic::Redeemers, Record>,
     ) -> Self {
         SmartContract {
             offchain_logic,
             backend,
         }
     }
+
+    pub fn backend(&self) -> &Backend<Logic::Datums, Logic::Redeemers, Record> {
+        &self.backend
+    }
+
+    pub fn offchain_logic(&self) -> &Logic {
+        &self.offchain_logic
+    }
 }
 
 #[async_trait]
-impl<'a, Logic, Record> SmartContractTrait for SmartContract<'a, Logic, Record>
+impl<Logic, Record> SmartContractTrait for SmartContract<Logic, Record>
 where
     Logic: SCLogic + Eq + Debug + Send + Sync,
     Record: LedgerClient<Logic::Datums, Logic::Redeemers> + Send + Sync,

--- a/tests/always_mints_contract.rs
+++ b/tests/always_mints_contract.rs
@@ -87,13 +87,13 @@ async fn can_mint_from_always_true_minting_policy() {
     // Call mint endpoint
     let amount = 69;
     let call = Endpoint::Mint { amount };
-    let contract = SmartContract::new(&AlwaysMintsSmartContract, &backend);
+    let contract = SmartContract::new(AlwaysMintsSmartContract, backend);
     contract.hit_endpoint(call).await.unwrap();
 
     // Check my balance for minted tokens
     let expected = amount;
     let actual = <TestLedgerClient<(), (), InMemoryStorage<()>> as LedgerClient<(), ()>>::balance_at_address(
-        &backend.ledger_client,
+        contract.backend().ledger_client(),
         &me,
         &policy,
     )

--- a/tests/transfer.rs
+++ b/tests/transfer.rs
@@ -63,7 +63,7 @@ async fn can_transfer_and_keep_remainder() {
         .finish_output()
         .build_in_memory();
 
-    let contract = SmartContract::new(&TransferADASmartContract, &backend);
+    let contract = SmartContract::new(TransferADASmartContract, backend);
 
     let call = Endpoint::Transfer {
         amount,
@@ -73,24 +73,27 @@ async fn can_transfer_and_keep_remainder() {
     contract.hit_endpoint(call).await.unwrap();
 
     let alice_expected = amount;
-    let alice_actual = backend
-        .ledger_client
+    let alice_actual = contract
+        .backend()
+        .ledger_client()
         .balance_at_address(&alice, &PolicyId::Lovelace)
         .await
         .unwrap();
     assert_eq!(alice_expected, alice_actual);
 
     let me_expected = input_amount - amount;
-    let me_actual = backend
-        .ledger_client
+    let me_actual = contract
+        .backend()
+        .ledger_client()
         .balance_at_address(&me, &PolicyId::Lovelace)
         .await
         .unwrap();
     assert_eq!(me_expected, me_actual);
 
     let expected_extra_amount = extra_amount;
-    let actual_extra_amount = backend
-        .ledger_client
+    let actual_extra_amount = contract
+        .backend()
+        .ledger_client()
         .balance_at_address(&me, &extra_policy)
         .await
         .unwrap();

--- a/trireme/src/balance.rs
+++ b/trireme/src/balance.rs
@@ -10,7 +10,7 @@ async fn run_lookup(lookup: TriremeLookups) -> Result<TriremeResponses> {
     let logic = TriremeLogic;
     let ledger_client = get_trireme_ledger_client_from_file().await?;
     let backend = Backend::new(ledger_client);
-    let contract = SmartContract::new(&logic, &backend);
+    let contract = SmartContract::new(logic, backend);
     let res = contract.lookup(lookup).await?;
     Ok(res)
 }


### PR DESCRIPTION
Since the `SmartContract` can just have getters on it for the owned types, there is no reason to add the additional complexity of lifetimes.